### PR TITLE
Fixed unexpected dynamic permission behavior

### DIFF
--- a/src/struct/CommandHandler.js
+++ b/src/struct/CommandHandler.js
@@ -401,9 +401,11 @@ class CommandHandler extends AkairoHandler {
         }
 
         if (command.clientPermissions) {
-            if (typeof command.clientPermissions === 'function' && !command.clientPermissions(message)) {
-                this.emit(CommandHandlerEvents.COMMAND_BLOCKED, message, command, BuiltInReasons.CLIENT_PERMISSIONS);
-                return true;
+            if (typeof command.clientPermissions === 'function') {
+                if (!command.clientPermissions(message)) {
+                    this.emit(CommandHandlerEvents.COMMAND_BLOCKED, message, command, BuiltInReasons.CLIENT_PERMISSIONS);
+                    return true;
+                }
             } else
             if (message.guild && !message.channel.permissionsFor(this.client.user).has(command.clientPermissions)) {
                 this.emit(CommandHandlerEvents.COMMAND_BLOCKED, message, command, BuiltInReasons.CLIENT_PERMISSIONS);
@@ -412,9 +414,11 @@ class CommandHandler extends AkairoHandler {
         }
 
         if (command.userPermissions) {
-            if (typeof command.userPermissions === 'function' && !command.userPermissions(message)) {
-                this.emit(CommandHandlerEvents.COMMAND_BLOCKED, message, command, BuiltInReasons.USER_PERMISSIONS);
-                return true;
+            if (typeof command.userPermissions === 'function') {
+                if (!command.userPermissions(message)) {
+                    this.emit(CommandHandlerEvents.COMMAND_BLOCKED, message, command, BuiltInReasons.USER_PERMISSIONS);
+                    return true;
+                }
             } else
             if (message.guild && !message.channel.permissionsFor(message.author).has(command.userPermissions)) {
                 this.emit(CommandHandlerEvents.COMMAND_BLOCKED, message, command, BuiltInReasons.USER_PERMISSIONS);


### PR DESCRIPTION
If `command.userPermissions` or `command.clientPermissions` is a _function_, it only works if **false** is returned. Looking at the source code, the problem is that if the first "if" statement fails (even if `command.userPermissions` is a function), the next statement assumes that `command.userPermissions` is a valid permission value, which it is not - it's an object of the function.

If the example userPermissions function displayed in the [gitbooks tutorials page](https://1computer1.gitbooks.io/akairo-tutorials/content/tutorials/commands/permissions.html)  returns **true**, this error gets thrown:
```
RangeError: Invalid permission string or number.
    at Function.resolve (D:\WORK\workspace-new\Projects\discord\node_modules\discord.js\src\util\Permissions.js:168:65)
    at Permissions.has (D:\WORK\workspace-new\Projects\discord\node_modules\discord.js\src\util\Permissions.js:62:35)
    at CommandHandler._runInhibitors (D:\WORK\workspace-new\Projects\discord\node_modules\discord-akairo\src\struct\CommandHandler.js:419:82)
    at preTest.then (D:\WORK\workspace-new\Projects\discord\node_modules\discord-akairo\src\struct\CommandHandler.js:333:26)
    at process._tickCallback (internal/process/next_tick.js:103:7)
```