### PR TITLE
Fix AkairoHandler#add

### DIFF
--- a/src/struct/AkairoHandler.js
+++ b/src/struct/AkairoHandler.js
@@ -176,7 +176,7 @@ class AkairoHandler extends EventEmitter {
         if (!path.extname(filename)) filename = `${filename}.js`;
 
         const files = this.constructor.readdirRecursive(this.directory);
-        const filepath = files.find(file => path.parse(file).base === filename);
+        const filepath = files.find(file => path.basename(file) === filename);
 
         if (!filepath) throw new AkairoError('FILE_NOT_FOUND', filename);
         return this.load(filepath);

--- a/src/struct/AkairoHandler.js
+++ b/src/struct/AkairoHandler.js
@@ -176,7 +176,7 @@ class AkairoHandler extends EventEmitter {
         if (!path.extname(filename)) filename = `${filename}.js`;
 
         const files = this.constructor.readdirRecursive(this.directory);
-        const filepath = files.find(file => file === filename);
+        const filepath = files.find(file => path.parse(file).base === filename);
 
         if (!filepath) throw new AkairoError('FILE_NOT_FOUND', filename);
         return this.load(filepath);


### PR DESCRIPTION
Currently, when calling `readdirRecursive`, it returns an array including the full filepath of each file. Then, AkairoHandler attempts to compare the file name included (ex. `Eval.js`) to the full file path (ex. `C:\\Users\\Owner\\Desktop\\Development\\Slice\\src\\Commands\\Owner\\Eval.js`). This means it will never find the file called `Eval.js` unless we were to include the full path *or compare it to the basename of the file*, in which this PR does.

Example eval to test.
```js
sa$eval const path = require('path');
const files = this.handler.constructor.readdirRecursive(this.handler.directory);
files.find(f => {
  return path.basename(f) == 'Eval.js';
});
```