### PR TITLE
Added automateAliases

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -446,6 +446,7 @@ declare module 'discord-akairo' {
     export type AkairoOptions = {
         aliasReplacement?: RegExp;
         allowMention?: boolean | AllowMentionFunction;
+        automateAliases?: boolean;
         automateCategories?: boolean;
         blockBots?: boolean;
         blockClient?: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -557,6 +557,7 @@ declare module 'discord-akairo' {
         description?: string | string[];
         editable?: boolean;
         options?: any;
+        automateAliases?: boolean;
         ownerOnly?: boolean;
         prefix?: string | string[] | PrefixFunction;
         protected?: boolean;

--- a/src/struct/AkairoClient.js
+++ b/src/struct/AkairoClient.js
@@ -33,7 +33,7 @@ const ListenerHandler = require('./ListenerHandler');
  * @prop {boolean} [blockBots=true] - Whether or not to block bots.
  * @prop {string} [listenerDirectory] - Directory to listeners.
  * @prop {Object} [emitters={}] - Emitters to load onto the listener handler.
- * @prop {boolean} [automateAliases=false] - Whether or not to add each module's id to its aliases array.
+ * @prop {boolean} [automateAliases=false] - Whether or not to add each module's id to it's aliases array. (Only used if the client option is true)
  * @prop {boolean} [automateCategories=false] - Whether or not to set each module's category to its parent directory name.
  * @prop {LoadFilterFunction} [loadFilter] - Filter for files to be loaded.
  * Can be set individually for each handler by overriding the `loadAll` method.

--- a/src/struct/AkairoClient.js
+++ b/src/struct/AkairoClient.js
@@ -33,6 +33,7 @@ const ListenerHandler = require('./ListenerHandler');
  * @prop {boolean} [blockBots=true] - Whether or not to block bots.
  * @prop {string} [listenerDirectory] - Directory to listeners.
  * @prop {Object} [emitters={}] - Emitters to load onto the listener handler.
+ * @prop {boolean} [automateAliases=false] - Whether or not to add each module's id to its aliases array.
  * @prop {boolean} [automateCategories=false] - Whether or not to set each module's category to its parent directory name.
  * @prop {LoadFilterFunction} [loadFilter] - Filter for files to be loaded.
  * Can be set individually for each handler by overriding the `loadAll` method.

--- a/src/struct/AkairoHandler.js
+++ b/src/struct/AkairoHandler.js
@@ -113,6 +113,11 @@ class AkairoHandler extends EventEmitter {
             mod.category = dirs[dirs.length - 1];
         }
 
+        if (mod.aliases && mod.aliases.length === 0 && this.client.akairoOptions.automateAliases) {
+            const file = path.basename(filepath).split('.')[0];
+            mod.aliases.push(file);
+        }
+
         if (!this.categories.has(mod.category)) this.categories.set(mod.category, new Category(mod.category));
         const category = this.categories.get(mod.category);
         mod.category = category;

--- a/src/struct/AkairoHandler.js
+++ b/src/struct/AkairoHandler.js
@@ -113,11 +113,6 @@ class AkairoHandler extends EventEmitter {
             mod.category = dirs[dirs.length - 1];
         }
 
-        if (mod.aliases && mod.aliases.length === 0 && this.client.akairoOptions.automateAliases) {
-            const file = path.basename(filepath).split('.')[0];
-            mod.aliases.push(file);
-        }
-
         if (!this.categories.has(mod.category)) this.categories.set(mod.category, new Category(mod.category));
         const category = this.categories.get(mod.category);
         mod.category = category;

--- a/src/struct/Command.js
+++ b/src/struct/Command.js
@@ -13,6 +13,7 @@ const { isPromise } = require('../util/Util');
  * @prop {ArgumentSplit|ArgumentSplitFunction} [split='plain'] - Method to split text into words.
  * @prop {string} [channel] - Restricts channel to either 'guild' or 'dm'.
  * @prop {string} [category='default'] - Category ID for organization purposes.
+ * @prop {boolean} [automateAliases=true] - Whether or not to add this module's id to it's aliases array.
  * @prop {boolean} [ownerOnly=false] - Whether or not to allow client owner(s) only.
  * @prop {boolean} [protected=false] - Whether or not this command cannot be disabled.
  * @prop {boolean} [typing=false] - Whether or not to type in channel during execution.
@@ -107,6 +108,7 @@ class Command extends AkairoModule {
             args = this.args,
             split = this.split || ArgumentSplits.PLAIN,
             channel = null,
+            automateAliases = true,
             ownerOnly = false,
             protect = false,
             editable = true,
@@ -146,6 +148,12 @@ class Command extends AkairoModule {
          * @type {?string}
          */
         this.channel = channel;
+
+        /**
+         * Manual override for the automateAliases client option per command.
+         * @type {boolean}
+         */
+        this.automateAliases = Boolean(automateAliases);
 
         /**
          * Usable only by the client owner.

--- a/src/struct/CommandHandler.js
+++ b/src/struct/CommandHandler.js
@@ -187,7 +187,7 @@ class CommandHandler extends AkairoHandler {
     _register(command, filepath) {
         super._register(command, filepath);
 
-        if (this.client.akairoOptions.automateAliases && this.automateAliases) command.aliases.push(command.id);
+        if (this.client.akairoOptions.automateAliases && command.automateAliases) command.aliases.push(command.id);
 
         this._addAliases(command);
     }

--- a/src/struct/CommandHandler.js
+++ b/src/struct/CommandHandler.js
@@ -6,7 +6,6 @@ const Command = require('./Command');
 const CommandUtil = require('./CommandUtil');
 const { isPromise } = require('../util/Util');
 const TypeResolver = require('./TypeResolver');
-const path = require('path');
 
 /** @extends AkairoHandler */
 class CommandHandler extends AkairoHandler {
@@ -188,10 +187,7 @@ class CommandHandler extends AkairoHandler {
     _register(command, filepath) {
         super._register(command, filepath);
 
-        if (command.aliases.length === 0 && this.client.akairoOptions.automateAliases) {
-            const file = path.basename(filepath).split('.')[0];
-            command.aliases.push(file);
-        }
+        if (command.aliases.length === 0 && this.client.akairoOptions.automateAliases) command.aliases.push(command.id);
 
         this._addAliases(command);
     }

--- a/src/struct/CommandHandler.js
+++ b/src/struct/CommandHandler.js
@@ -187,7 +187,7 @@ class CommandHandler extends AkairoHandler {
     _register(command, filepath) {
         super._register(command, filepath);
 
-        if (command.aliases.length === 0 && this.client.akairoOptions.automateAliases) command.aliases.push(command.id);
+        if (this.client.akairoOptions.automateAliases && this.automateAliases) command.aliases.push(command.id);
 
         this._addAliases(command);
     }

--- a/src/struct/CommandHandler.js
+++ b/src/struct/CommandHandler.js
@@ -6,6 +6,7 @@ const Command = require('./Command');
 const CommandUtil = require('./CommandUtil');
 const { isPromise } = require('../util/Util');
 const TypeResolver = require('./TypeResolver');
+const path = require('path');
 
 /** @extends AkairoHandler */
 class CommandHandler extends AkairoHandler {
@@ -186,6 +187,12 @@ class CommandHandler extends AkairoHandler {
      */
     _register(command, filepath) {
         super._register(command, filepath);
+
+        if (command.aliases.length === 0 && this.client.akairoOptions.automateAliases) {
+            const file = path.basename(filepath).split('.')[0];
+            command.aliases.push(file);
+        }
+
         this._addAliases(command);
     }
 


### PR DESCRIPTION
I added an automateAliases that adds the filename to the mod's aliases if it has an aliases array (command), and the length is 0 and the client option is enabled.

This still allowes you to keep that option as false if you don't like it.
This still allowes you to manually set an array per command and it wont add the filename to it.