### PR TITLE
Fixed AkairoHandler findExport

### DIFF
--- a/src/struct/AkairoHandler.js
+++ b/src/struct/AkairoHandler.js
@@ -144,7 +144,7 @@ class AkairoHandler extends EventEmitter {
             : function findExport(m) {
                 if (!m) return null;
                 if (m.prototype instanceof this.classToHandle) return m;
-                return m.default ? findExport(m.default) : null;
+                return m.default ? findExport.call(this, m.default) : null;
             }.call(this, require(thing));
 
         if (mod && mod.prototype instanceof this.classToHandle) {


### PR DESCRIPTION
Passing the current context will prevent `this` from referencing something else than the AkairoHandler class and throw an error when trying to access the `classToHandle` property.