### PR TITLE
Handlers: Allow Chaining

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -909,20 +909,24 @@ class CommandHandler extends AkairoHandler {
     /**
      * Set the inhibitor handler to use.
      * @param {InhibitorHandler} inhibitorHandler - The inhibitor handler.
-     * @returns {void}
+     * @returns {CommandHandler}
      */
     useInhibitorHandler(inhibitorHandler) {
         this.inhibitorHandler = inhibitorHandler;
         this.resolver.inhibitorHandler = inhibitorHandler;
+
+        return this;
     }
 
     /**
      * Set the listener handler to use.
      * @param {ListenerHandler} listenerHandler - The listener handler.
-     * @returns {void}
+     * @returns {CommandHandler}
      */
     useListenerHandler(listenerHandler) {
         this.resolver.listenerHandler = listenerHandler;
+
+        return this;
     }
 
     /**

--- a/src/struct/listeners/ListenerHandler.js
+++ b/src/struct/listeners/ListenerHandler.js
@@ -116,6 +116,8 @@ class ListenerHandler extends AkairoHandler {
             if (!isEventEmitter(value)) throw new AkairoError('INVALID_TYPE', key, 'EventEmitter', true);
             this.emitters.set(key, value);
         }
+
+        return this;
     }
 
     /**


### PR DESCRIPTION
```js
this.commandHandler
  .useInhibitorHandler(this.inhibitorHandler)
  .useListenerHandler(this.listenerHandler)
  .loadAll();
```
Instead of
```js
this.commandHandler.useInhibitorHandler(this.inhibitorHandler);
this.commandHandler.useListenerHandler(this.listenerHandler);
this.commandHandler.loadAll();
```