### PR TITLE
Feat: Command Locks

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -680,9 +680,9 @@ declare module 'discord-akairo' {
 
     export type ExecutionPredicate = (message: Message) => boolean;
 
-    export type KeyGenerator = (message: Message, args: any) => string;
-
     export type IgnoreCheckPredicate = (message: Message, command: Command) => boolean;
+
+    export type KeyGenerator = (message: Message, args: any) => string;
 
     export type LoadPredicate = (filepath: string) => boolean;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -173,6 +173,8 @@ declare module 'discord-akairo' {
         public filepath: string;
         public handler: CommandHandler;
         public id: string;
+        public lock?: KeyGenerator;
+        public locker?: Set<string>;
         public ignoreCooldown?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
         public ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
         public ownerOnly: boolean;
@@ -588,6 +590,7 @@ declare module 'discord-akairo' {
         defaultPrompt?: ArgumentPromptOptions;
         description?: StringResolvable;
         editable?: boolean;
+        lock?: KeyGenerator | 'guild' | 'channel' | 'user';
         ignoreCooldown?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
         ignorePermissions?: Snowflake | Snowflake[] | IgnoreCheckPredicate;
         ownerOnly?: boolean;
@@ -677,6 +680,8 @@ declare module 'discord-akairo' {
 
     export type ExecutionPredicate = (message: Message) => boolean;
 
+    export type KeyGenerator = (message: Message, args: any) => string;
+
     export type IgnoreCheckPredicate = (message: Message, command: Command) => boolean;
 
     export type LoadPredicate = (filepath: string) => boolean;
@@ -759,6 +764,7 @@ declare module 'discord-akairo' {
             COMMAND_STARTED: 'commandStarted',
             COMMAND_FINISHED: 'commandFinished',
             COMMAND_CANCELLED: 'commandCancelled',
+            COMMAND_LOCKED: 'commandLocked',
             MISSING_PERMISSIONS: 'missingPermissions',
             COOLDOWN: 'cooldown',
             IN_PROMPT: 'inPrompt',

--- a/src/struct/commands/Command.js
+++ b/src/struct/commands/Command.js
@@ -154,7 +154,7 @@ class Command extends AkairoModule {
 
         /**
          * The key generator for the locker.
-         * @type {KeyGenerator}
+         * @type {?KeyGenerator}
          */
         this.lock = lock;
 
@@ -169,7 +169,7 @@ class Command extends AkairoModule {
         if (this.lock) {
             /**
              * Stores the current locks.
-             * @type {Set<string>}
+             * @type {?Set<string>}
              */
             this.locker = new Set();
         }

--- a/src/struct/commands/Command.js
+++ b/src/struct/commands/Command.js
@@ -154,6 +154,7 @@ class Command extends AkairoModule {
 
         /**
          * The key generator for the locker.
+         * @type {KeyGenerator}
          */
         this.lock = lock;
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -62,6 +62,7 @@ module.exports = {
         COMMAND_STARTED: 'commandStarted',
         COMMAND_FINISHED: 'commandFinished',
         COMMAND_CANCELLED: 'commandCancelled',
+        COMMAND_LOCKED: 'commandLocked',
         MISSING_PERMISSIONS: 'missingPermissions',
         COOLDOWN: 'cooldown',
         IN_PROMPT: 'inPrompt',

--- a/test/commands/lock.js
+++ b/test/commands/lock.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-console */
+
+const { Command } = require('../..');
+const sleep = require('util').promisify(setTimeout);
+
+class LockCommand extends Command {
+    constructor() {
+        super('lock', {
+            aliases: ['lock'],
+            lock: 'guild'
+        });
+    }
+
+    exec(message) {
+        return [0, 1, 2, 3, 4].reduce((promise, num) => promise.then(() => sleep(1000)).then(() => message.util.send(num)), Promise.resolve());
+    }
+}
+
+module.exports = LockCommand;


### PR DESCRIPTION
Allows the restriction of concurrent command usage. Useful for commands that take a while, use awaitMessages, etc.