### PR TITLE
Fix typings for ParsedComponentData

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -638,7 +638,7 @@ declare module 'discord-akairo' {
     } & AkairoModuleOptions;
 
     export type ParsedComponentData = {
-        afterContent?: string;
+        afterPrefix?: string;
         alias?: string;
         command?: Command;
         content?: string;


### PR DESCRIPTION
This was named afterContent (probably a left over)

https://github.com/1Computer1/discord-akairo/blob/d404e6f7e0a98c71708801d5ce5d163b224a88e2/src/struct/commands/CommandUtil.js#L173-L181

https://github.com/1Computer1/discord-akairo/blob/e901a1e25b871e61782877508c5de9e56ea4cd60/src/struct/commands/CommandHandler.js#L809-L816