### PR TITLE
Typings: ClientUtil#collection parameter should be optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -136,7 +136,7 @@ declare module 'discord-akairo' {
         public checkMember(text: string, member: GuildMember, caseSensitive?: boolean, wholeWord?: boolean): boolean;
         public checkRole(text: string, role: Role, caseSensitive?: boolean, wholeWord?: boolean): boolean;
         public checkUser(text: string, user: User, caseSensitive?: boolean, wholeWord?: boolean): boolean;
-        public collection<K, V>(iterable: Iterable<[K, V][]>): Collection<K, V>;
+        public collection<K, V>(iterable?: Iterable<[K, V][]>): Collection<K, V>;
         public compareStreaming(oldMember: GuildMember, newMember: GuildMember): number;
         public embed(data?: object): MessageEmbed;
         public fetchMember(guild: Guild, id: string, cache?: boolean): Promise<GuildMember>;


### PR DESCRIPTION
ClientUtil#collection causes TS error when invoked without passing an iterable, which it should not:
#### Akairo
![image](https://user-images.githubusercontent.com/32944712/51839402-1a72f300-2344-11e9-9382-4b8068a51163.png)

#### Discord.JS
![image](https://user-images.githubusercontent.com/32944712/51839332-ea2b5480-2343-11e9-8d31-a91acbaf6bf6.png)

