### PR TITLE
typings: classToHandle takes Function instead of string

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -527,7 +527,7 @@ declare module 'discord-akairo' {
 
     export type AkairoHandlerOptions = {
         automateCategories?: boolean;
-        classToHandle?: string;
+        classToHandle?: Function;
         directory?: string;
         extensions?: string[] | Set<string>;
         loadFilter?: LoadPredicate;


### PR DESCRIPTION
Reflects the [docs](https://1computer1.github.io/discord-akairo/master/global.html#AkairoHandlerOptions)